### PR TITLE
chore(grunt): adds load-grunt-tasks module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,14 +1,6 @@
 module.exports = function (grunt) {
 
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-conventional-changelog');
-  grunt.loadNpmTasks('grunt-karma');
+  require('load-grunt-tasks')(grunt);
 
   grunt.initConfig({
     dist: 'dist',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-conventional-changelog": "git://github.com/ajoslin/grunt-conventional-changelog",
     "semver": "~1.1.4",
-    "grunt-shell": "~0.2.2"
+    "grunt-shell": "~0.2.2",
+    "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
this commit adds the load-grunt-tasks module which makes it easier to
maintain grunt tasks that have to be loaded.
