### PR TITLE
Adding compatibility with the AngularJS 1.2

### DIFF
--- a/promise-tracker.js
+++ b/promise-tracker.js
@@ -260,7 +260,7 @@ angular.module('ajoslin.promise-tracker')
       //## addPromise()
       //Adds a given promise to our tracking
       self.addPromise = function(promise, startArg) {
-        var then = promise && (promise.$then || promise.then);
+        var then = promise && (promise.$then || promise.then || promise.$promise.then); //Adding compatibility with the angular 1.2
         if (!then) {
           throw new Error("promiseTracker#addPromise expects a promise object!");
         }


### PR DESCRIPTION
In the last Angular stable release the resource.$then has been removed.
Resource instances do not have a $then function anymore. 
Use the $promise.then instead.

More info:
http://docs.angularjs.org/guide/migration#resource$then-has-been-removed
