### PR TITLE
Fixed issue in IE causing "SCRIPT1004: Expected ';'" error

### DIFF
--- a/promise-tracker.js
+++ b/promise-tracker.js
@@ -56,7 +56,7 @@ angular.module('ajoslin.promise-tracker', [])
       };
 
       //Create a promise that will make our tracker active until it is resolved.
-      //@return deferred - our deferred object that is being tracked
+      // @return deferred - our deferred object that is being tracked
       self.createPromise = function() {
         var deferred = $q.defer();
         tracked.push(deferred);

--- a/src/promise-tracker.js
+++ b/src/promise-tracker.js
@@ -49,7 +49,7 @@ angular.module('ajoslin.promise-tracker', [])
       };
 
       //Create a promise that will make our tracker active until it is resolved.
-      //@return deferred - our deferred object that is being tracked
+      // @return deferred - our deferred object that is being tracked
       self.createPromise = function() {
         var deferred = $q.defer();
         tracked.push(deferred);


### PR DESCRIPTION
The comment

```
//@return deferred - our deferred object that is being tracked
```

always causes a "SCRIPT1004: Expected ';'" error in IE10. By adding a space before the @-sign, this problem can be circumvented.
