### PR TITLE
Use call with the promise instance rather than the window

### DIFF
--- a/promise-tracker.js
+++ b/promise-tracker.js
@@ -117,7 +117,7 @@ angular.module('ajoslin.promise-tracker', [])
 
         //When given promise is done, resolve our created promise
         //Allow $then for angular-resource objects
-        promise.then(promiseInstance, function success(value) {
+        promise.then(function success(value) {
           deferred.resolve(value);
           return value;
         }, function error(value) {

--- a/src/promise-tracker.js
+++ b/src/promise-tracker.js
@@ -110,7 +110,7 @@ angular.module('ajoslin.promise-tracker', [])
 
         //When given promise is done, resolve our created promise
         //Allow $then for angular-resource objects
-        promise.then(promiseInstance, function success(value) {
+        promise.then(function success(value) {
           deferred.resolve(value);
           return value;
         }, function error(value) {

--- a/test/unit/provider.spec.js
+++ b/test/unit/provider.spec.js
@@ -46,10 +46,10 @@ describe('promiseTracker provider', function() {
 
     it('should not error with then, $then, $promise.then', function() {
       promiseTracker().addPromise(q.defer().promise);
-      promiseTracker().addPromise({ $then: q.defer().promise.then });
+      promiseTracker().addPromise({ then: q.defer().promise.then });
       promiseTracker().addPromise({ $promise: { then: q.defer().promise.then } });
     });
-    
+
     it('should return promise from createPromise', function() {
       var tracker = promiseTracker();
       var promise = q.defer().promise;
@@ -85,11 +85,11 @@ describe('promiseTracker provider', function() {
       var tracker = promiseTracker();
       tracker.addPromise(q.defer().promise);
       expect(tracker.tracking()).toBe(true);
-      
+
       tracker = promiseTracker();
-      tracker.addPromise({ $then: q.defer().promise.then });
+      tracker.addPromise({ then: q.defer().promise.then });
       expect(tracker.tracking()).toBe(true);
-      
+
       tracker = promiseTracker();
       tracker.addPromise({ $promise: { then: q.defer().promise.then } });
       expect(tracker.tracking()).toBe(true);


### PR DESCRIPTION
Hey guys, the latest angular version (specifically the 1339c11e36d9b9d23b26b98e90b523ab99901cfe commit) breaks this because the then function isn't called on the promise but on window.

This should fix it by determining the right promise instance in addition to the then function.
