### PR TITLE
Move angular from devDependencies to dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,8 +25,10 @@
     "promise-tracker.js",
     "promise-tracker-http-interceptor.js"
   ],
+  "dependencies": {
+    "angular": ">=1.3.0"
+  },
   "devDependencies": {
-    "angular": "1.3.x",
     "angular-mocks": "1.3.x",
     "angular-resource": "1.3.x"
   }


### PR DESCRIPTION
Not sure what the minimum supported angular is, but it should be listed in bower.json.

This is useful with libraries that analyze bower.json, e.g. [main-bower-files](https://github.com/ck86/main-bower-files). (To use main-bower-files with angular-promise-tracker, it's currently necessary to put in a manual override inside your own project's bower.json for angular-promise-tracker's dependency on angular: otherwise, it will load this package before angular.)