### PR TITLE
simplify http-interceptor even more

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,8 +26,8 @@
     "promise-tracker-http-interceptor.js"
   ],
   "devDependencies": {
-    "angular": "1.3.x",
-    "angular-mocks": "1.3.x",
-    "angular-resource": "1.3.x"
+    "angular": "1.4.x",
+    "angular-mocks": "1.4.x",
+    "angular-resource": "1.4.x"
   }
 }


### PR DESCRIPTION
- needs IE 9+ for Array.prototype.forEach and Function.prototype.bind
- needs angular 1.4+ for $q.resolve alias of when (to maintain naming
consistency with ES6)

if you don't like the angular 1.4 dependency I coud update the PR.